### PR TITLE
use global environment rebar executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 compile:
-	./rebar compile
-	./rebar escriptize
+	rebar compile
+	rebar escriptize


### PR DESCRIPTION
After removing the rebar executable it is a good idea
to point to a global environment rebar executable
for less confusion.
