### PR TITLE
Make appname configurable when running from command line

### DIFF
--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -56,6 +56,8 @@ update_config(src, Value, Config) ->
     Config#config{sources = Value};
 update_config(prefix, Value, Config) ->
     Config#config{prefix_len = list_to_integer(Value)};
+update_config(appname, Value, Config) ->
+    Config#config{appname = list_to_atom(Value)};
 update_config(_Other, _Value, _Config) ->
     usage(),
     halt(1).


### PR DESCRIPTION
Enables customization of the 'Application' default.
