### PR TITLE
Rebar plugin should import cover data for eunit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Standalone:
    Configure rebar to generate reports in `Cobertura` format:
 
         {plugins, [rebar_covertool]}.
-        {covertool_eunit, "eunit.coverage.xml"}. % Output report file name
+        {cover_export_enabled, true}.
+        {covertool_eunit, {".eunit/eunit.coverdata", "eunit.coverage.xml"}}. % Source file name, output report file name
         {covertool_ct, {"ct.coverdata", "ct.coverage.xml"}}. % Source file name, output report file name
         {covertool_prefix_len, 2}. % Optional: Use module prefix as (imaginary) package name
 

--- a/src/rebar_covertool.erl
+++ b/src/rebar_covertool.erl
@@ -7,29 +7,19 @@
 
 -define(EUNIT_DIR, ".eunit").
 
-%% Run after eunit tests, export current coverage data in Cobertura format
+%% Run after eunit tests. Convert coverage data exported after tests are
+%% executed into Cobertura format.
 eunit(Config, AppFile) ->
-    AppName = get_app_name(Config, AppFile),
-    case rebar_config:get_local(Config, covertool_eunit, undefined) of
-        undefined -> ok;
-        Output ->
-            {ok, CoverLog} = cover_init(),
-            PrefixLen = rebar_config:get_local(Config, covertool_prefix_len, 0),
-            CoverConfig = #config{appname = AppName,
-                                  prefix_len = PrefixLen,
-                                  output = Output,
-                                  sources = "src/"},
-            covertool:generate_report(CoverConfig,
-                                      cover:modules() ++ cover:imported_modules()),
-            file:close(CoverLog),
-            ok
-    end.
+    generate_report(Config, AppFile, covertool_eunit).
 
 %% Run after common tests. Convert coverage data exported after tests are
 %% executed into Cobertura format.
 ct(Config, AppFile) ->
+    generate_report(Config, AppFile, covertool_ct).
+
+generate_report(Config, AppFile, ConfigKey) ->
     AppName = get_app_name(Config, AppFile),
-    case rebar_config:get_local(Config, covertool_ct, undefined) of
+    case rebar_config:get_local(Config, ConfigKey, undefined) of
         undefined -> ok;
         {From, To} ->
             {ok, CoverLog} = cover_init(),


### PR DESCRIPTION
In newer versions of rebar cover is stopped after a eunit run. Made
rebar_covertool rely on importing the cover data instead of relying
on a running cover_server.
