### PR TITLE
Fixes a crash with multi-app projects when one of the app do not use CT.

### DIFF
--- a/src/rebar_covertool.erl
+++ b/src/rebar_covertool.erl
@@ -20,7 +20,12 @@ eunit(Config, AppFile) ->
 %% Run after common tests. Convert coverage data exported after tests are
 %% executed into Cobertura format.
 ct(Config, AppFile) ->
-    generate_report(Config, AppFile, covertool_ct).
+    case is_empty_dir(AppFile) of
+        true ->
+            ok;
+        false ->
+            generate_report(Config, AppFile, covertool_ct)
+    end.
 
 generate_report(Config, AppFile, ConfigKey) ->
     AppName = get_app_name(Config, AppFile),


### PR DESCRIPTION
When a project have multiple applications and one of them do not have any Common Test suites, rebar ct fails when using covertool.

This Fix it the same way it was done for eunit.
