### PR TITLE
Create .eunit directory to avoid crash if not using eunit

### DIFF
--- a/src/rebar_covertool.erl
+++ b/src/rebar_covertool.erl
@@ -77,7 +77,9 @@ cover_init() ->
                          {error, _Reason} = ErrorStart ->
                              ErrorStart
                      end,
-    {ok, F} = file:open(filename:join([?EUNIT_DIR, "cover.log"]), [write, append]),
+    CoverLog = filename:join([?EUNIT_DIR, "cover.log"]),
+    ok = filelib:ensure_dir(CoverLog),
+    {ok, F} = file:open(CoverLog, [write, append]),
     group_leader(F, CoverPid),
     {ok, F}.
 


### PR DESCRIPTION
If using only Common Test, e.g. `rebar ct`, and no `.eunit` directory exists, `rebar_covertool` crashes.

I thought it harmless to put in a little code to create the directory if it does not exist.
