### PR TITLE
Restore "sources" argument to config

### DIFF
--- a/include/covertool.hrl
+++ b/include/covertool.hrl
@@ -1,5 +1,6 @@
--record(config, {appname = "Application",
+-record(config, {appname = 'Application',
                  prefix_len = 0,
                  cover_data = no_import,
                  output = "coverage.xml",
-                 beams}).
+                 sources = ["src/"],
+                 beams = ["ebin/"]}).

--- a/src/mix_covertool.erl
+++ b/src/mix_covertool.erl
@@ -19,8 +19,9 @@ start( CompilePath, _Opts ) ->
     end,
 
     AppName = proplists:get_value(app, mix_project(config)),
+    {ok, SrcDir} = file:get_cwd(),
     BeamDir = binary:bin_to_list(mix_project(compile_path)),
-    Config = #config{appname = AppName, beams = [BeamDir]},
+    Config = #config{appname = AppName, sources = [SrcDir], beams = [BeamDir]},
 
     fun() ->
         covertool:generate_report(Config, cover:modules())

--- a/src/rebar3_covertool_gen.erl
+++ b/src/rebar3_covertool_gen.erl
@@ -108,8 +108,14 @@ generate_apps( State, Apps, LogFile ) ->
 generate_app(State, App, Result) ->
     OutputFile = filename:join(outdir(State), atom_to_list(App) ++ ".covertool.xml"),
     EbinPath = [filename:join([rebar_dir:base_dir(State), "lib", atom_to_list(App), "ebin"])],
+    CurrProfileDir = rebar_dir:base_dir(State),
+    DefaultProfileDir = rebar_dir:profile_dir(rebar_state:opts(State), [default]),
+    SrcPath = [filename:join([ProfileDir, "lib", atom_to_list(App), "src"])
+               || ProfileDir <- lists:usort([CurrProfileDir, DefaultProfileDir])],
     PrefixLen = prefix_len(State),
-    Config = #config{ appname = App, output = OutputFile, beams = [EbinPath], prefix_len = PrefixLen},
+    Config = #config{ appname = App, output = OutputFile,
+                      sources = SrcPath, beams = EbinPath,
+                      prefix_len = PrefixLen},
     case covertool:generate_report( Config, cover:imported_modules() ) of
         ok -> Result;
         Otherwise -> Otherwise


### PR DESCRIPTION
* Restores the `#config.sources` argument removed in #35. Now, however, this is only used for forming "relative" paths to the source files in package names. As such, it's "optional."
  * Consolidates the default values for `#config.sources` into the covertool.hrl
  * Implements a new source path check for trimming the absolute path off of source files. This works identically to the previous version, but integrates with @tverlaan's change to lookup the source using `beam_lib:chunks/2`.
* Updates `rebar3_covertool_gen` to set `#config.sources` for the `src` dir for the current and default profiles, since it seems that the compiled beams typically reference the path in the default directory
* Updates `mix_covertool` to set `#config.sources` as the `cwd`, so that it should work as previously.