### PR TITLE
Update covertool.erl

### DIFF
--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -193,7 +193,7 @@ generate_package(PackageName, Modules) ->
                       {'branch-rate', rate(Classes#result.branches)},
                       {complexity, 0}],
             [{classes, Classes#result.data}]},
-    #result{data = Data}.
+    Classes#result{data = Data}.
 
 % generate <classes> element, each Erlang module is "class"
 generate_classes(Modules) ->


### PR DESCRIPTION
I have an issue while using covertool on my ct.coverdata file. Each XML files for all my Erlang apps have line-rate="0" lines-covered="0".

It seems that the data is lost at line 196 in generate_package(..).
It should return Classes#result{data = Data}. instead of #result{data = Data}