### PR TITLE
Add missing `branch` field in lines

### DIFF
--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -219,7 +219,8 @@ generate_class(Module) ->
                   Covered = case Value of 0 -> 0; _Other -> 1 end,
                   LineCoverage = sum(Result#result.line, {Covered, 1}), % add one line to the summary
                   Data = {line, [{number, Line},
-                                 {hits, Value}],
+                                 {hits, Value},
+                                 {branch, "False"}],
                           []},
                   {Data, Result#result{line = LineCoverage}}
           end,


### PR DESCRIPTION
Azure DevOps CI fails to read the file if the `branch` field is not specified. Since the feature of branching does not seem to be supported at the moment by the tool, I set it to `false`.