### PR TITLE
Fix unit tests and remove rebar dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: erlang
+otp_release:
+  - 19.3
+  - 20.3
+  - 21.3
+branches:
+  only:
+    - master
+    - /^[0-9]+\.[0-9]+\.[0-9]+/
+install: true
+script:
+  - make

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,12 @@
 
 .PHONY : all deps compile test clean
 all: deps compile test
-ifdef REBAR
+REBAR?=rebar
 deps:
-	$(info REBAR is $(REBAR))
-else
-REBAR=rebar
-deps:
-	@$(REBAR) get-deps update-deps
-	$(MAKE) -C deps/rebar
-endif
+	@$(REBAR) get-deps
 compile:
 	@$(REBAR) compile escriptize
 test:
 	-@$(REBAR) skip_deps=true eunit
 clean:
 	@$(REBAR) clean
-	@rm cover.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cover-to-Cobertura Conversion Tool 
 
+[![Build Status](https://travis-ci.org/nalundgaard/covertool.svg?branch=master)](https://travis-ci.org/nalundgaard/covertool)
+
 [![Hex.pm version](https://img.shields.io/hexpm/v/covertool.svg?style=flat)](https://hex.pm/packages/covertool)
 
 A simple tool to convert exported Erlang `cover` data sets into Cobertura XML
@@ -7,7 +9,7 @@ reports. The report could be then feed to the Jenkins Cobertura plug-in.
 
 ## Plugin rename notice
 
-This plugin is now known on [Hex](https://hex.pm) as [`covertool`](https://hex.pm/packages/covertool). Previously, is was called [`rebar_covertool`](https://hex.pm/packages/rebar_covertool). That package name is now **retired**, although it will remain compatible.
+This plugin is now known on [Hex](https://hex.pm) as [`covertool`](https://hex.pm/packages/covertool). Previously, it was called [`rebar_covertool`](https://hex.pm/packages/rebar_covertool). That package name is now **retired**, although it will remain compatible.
 
 As of `covertool` 1.3.0, the `covertool` Erlang module now contains callbacks for all supported plugin formats (rebar 2, rebar3, and mix). Going forward, referencing `covertool` as `rebar_covertool` or `mix_covertool` in plugins is **deprecated**. Use `covertool` instead (see [usage](#usage) below).
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [nowarn_untyped_record]}.
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
-{deps,
-    [
-        {rebar, ".*", {git, "https://github.com/rebar/rebar.git", {tag, "2.6.0"}}}
-    ]}.
+{eunit_compile_opts, [export_all]}.
+{deps, []}.
+{post_hooks, [{clean, "rm -f cover.xml"}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,9 +1,0 @@
-case os:getenv("REBAR") of
-    Missing when Missing =:= false; Missing =:= [] ->
-        %% we are not building covertool directly, so do *not* fetch rebar
-        {value, {deps, DepList}, RestConfig} = lists:keytake( deps, 1, CONFIG ),
-        NewDepList = lists:keydelete( rebar, 1, DepList ),
-        [{deps, NewDepList} | RestConfig];
-    _RebarCmd -> CONFIG
-end.
-

--- a/src/covertool.app.src
+++ b/src/covertool.app.src
@@ -1,7 +1,7 @@
 {application, covertool,
  [
   {description, "Build tool & plugin for generating Cobertura XML reports"},
-  {vsn, "2.0.0"},
+  {vsn, "2.0.1"},
   {registered, []},
   {applications, [kernel, stdlib]},
   {env, []},


### PR DESCRIPTION
* Refactor unit tests to build the test application and execute using the client's provided eunit command (use `os:find_executable/1` to get it if it's not provided as a full path in the `$REBAR` environment variable)
* Fix the unit tests to be compatible with the latest output format.
* Remove rebar as an explicit dependency
* Update app.src version to 2.0.1
* Support building with travis-ci
* Resolves #44