### PR TITLE
Fix covertool link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cover-to-Cobertura Conversion Tool 
 
-[![Build Status](https://travis-ci.org/nalundgaard/covertool.svg?branch=master)](https://travis-ci.org/nalundgaard/covertool)
+[![Build Status](https://travis-ci.org/covertool/covertool.svg?branch=master)](https://travis-ci.org/covertool/covertool)
 
 [![Hex.pm version](https://img.shields.io/hexpm/v/covertool.svg?style=flat)](https://hex.pm/packages/covertool)
 


### PR DESCRIPTION
I have set up travis-ci on my personal fork, https://github.com/nalundgaard/covertool/, in order to verify the travis file. That is [working nicely](https://travis-ci.org/nalundgaard/covertool/builds/585593798). Now I would like to have travis-ci set up for the mainline project, and linked in the README, as this change optimistically references.

@idubrov this is contingent on you (as an owner of the covertool organization) accepting the request I have made to add travis-ci access. Alternately, you could make me an owner of the covertool organization so that I can take care of this.