### PR TITLE
Hex pkg: Remove deprecated "maintainers" property

### DIFF
--- a/src/covertool.app.src
+++ b/src/covertool.app.src
@@ -6,7 +6,6 @@
   {applications, [kernel, stdlib]},
   {env, []},
   {pkg_name, covertool},
-  {maintainers, ["Tristan Sloughter", "Timmo Verlaan", "Nicholas Lundgaard", "Ivan Dubrov"]},
   {licenses, ["2-Clause BSD"]},
   {links, [{"Github", "https://github.com/covertool/covertool"}]}
  ]}.


### PR DESCRIPTION
Removes this deprecated property so that we can continue to publish covertool as a Hex package.