### PR TITLE
Add Erlang/OTP 22 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ otp_release:
   - 19.3
   - 20.3
   - 21.3
+  - 22.0
 branches:
   only:
     - master


### PR DESCRIPTION
I forgot to include this new Erlang release in the original PR (#52).