### PR TITLE
Update Makefile to use rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-deps/
-ebin/
-covertool
+/_build
+/covertool
+TEST-*.xml
 rpc_monitor*
-.eunit
 .project
 .settings
 erlide.log

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@
 .PHONY : all deps compile test clean
 all: deps compile test
 REBAR?=rebar
+REBAR3?=rebar3
 deps:
-	@$(REBAR) get-deps
+	@$(REBAR3) get-deps
 compile:
-	@$(REBAR) compile escriptize
+	@$(REBAR3) compile
+	@$(REBAR3) escriptize
+	@cp -f _build/default/bin/covertool .
 test:
-	-@$(REBAR) skip_deps=true eunit
+	-@$(REBAR3) eunit
 clean:
-	@$(REBAR) clean
+	@$(REBAR3) clean
+	@rm -f covertool

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [nowarn_untyped_record]}.
-{eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.
+{eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "test"}]}}]}.
 {eunit_compile_opts, [export_all]}.
 {deps, []}.
-{post_hooks, [{clean, "rm -f cover.xml"}]}.
+{post_hooks, [{clean, "rm -rf _build/default/bin cover.xml test/TEST-*.xml"}]}.


### PR DESCRIPTION
* rebar 2.6.0+ is still required to be installed for unit tests to pass
* Sets the stage to build rebar3-based tests too