### PR TITLE
Allow user provided source file lookup function

### DIFF
--- a/include/covertool.hrl
+++ b/include/covertool.hrl
@@ -4,4 +4,6 @@
                  output = "coverage.xml",
                  summary = false,
                  sources = ["src/"],
-                 beams = ["ebin/"]}).
+                 beams = ["ebin/"],
+                 lookup_source = no_callback :: no_callback | fun((module()) -> string() | false)
+                }).

--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -103,6 +103,7 @@ generate_report(Config, Modules) ->
     end,
     put(src, Config#config.sources),
     put(ebin, Config#config.beams),
+    put(lookup_source, Config#config.lookup_source),
     io:format("Generating report '~s'...~n", [Output]),
     Prolog = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
               "<!DOCTYPE coverage SYSTEM \"http://cobertura.sourceforge.net/xml/coverage-04.dtd\">\n"],
@@ -303,7 +304,12 @@ percentage({Covered, Valid}) ->
 
 % lookup source in source directory
 lookup_source(Module) ->
-    lookup_source(get(ebin), Module).
+    case get(lookup_source) of
+        no_callback ->
+            lookup_source(get(ebin), Module);
+        Fn ->
+            Fn(Module)
+    end.
 
 lookup_source([EbinDir | RDirs], M) ->
     Beam = io_lib:format("~s/~s.beam", [EbinDir, M]),


### PR DESCRIPTION
Thank you for the great tool.

We are trying to use this as a embedded component in our project.
The `lookup_source/1` is not working for us, because we enable `deterministic` compilation flag,
When `deterministic` is used, source file is not found in `compile_info`.

In this PR, I try to build a module to source mapping before the call, and provide a callback from the config.
Hope this can help others too.
