### PR TITLE
Store abspath of src dirs so that class paths are correctly relative

### DIFF
--- a/src/covertool.erl
+++ b/src/covertool.erl
@@ -101,7 +101,7 @@ generate_report(Config, Modules) ->
         CoverData ->
             cover:import(CoverData)
     end,
-    put(src, Config#config.sources),
+    put(src, [filename:absname(SrcDir) || SrcDir <- Config#config.sources]),
     put(ebin, Config#config.beams),
     io:format("Generating report '~s'...~n", [Output]),
     Prolog = ["<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
@@ -120,7 +120,7 @@ generate_report(Config, Modules) ->
     {BranchesCovered, BranchesValid} = Result#result.branches,
     BranchRate = rate(Result#result.branches),
 
-    Sources = [{source, [filename:absname(SrcDir)]} || SrcDir <- get(src)],
+    Sources = [{source, [SrcDir]} || SrcDir <- get(src)],
 
     Root = {coverage, [{timestamp, Timestamp},
                        {'line-rate', LineRate},


### PR DESCRIPTION
When passing a relative path to `-src` argument the source path in the generated XML is correctly transformed to an absolute one but class paths remain absolute when they should be relative to the ones of the source. This happens because class paths are calculated before transforming source ones to absolute.