### PR TITLE
Update application configuration to make it compatible with Elixir 1.15

### DIFF
--- a/src/covertool.app.src
+++ b/src/covertool.app.src
@@ -3,7 +3,7 @@
   {description, "Build tool & plugin for generating Cobertura XML reports"},
   {vsn, "2.0.5"},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, xmerl, tools]},
   {env, []},
   {pkg_name, covertool},
   {licenses, ["2-Clause BSD"]},


### PR DESCRIPTION
`xmerl` and `tools` (containing the `cover` module) are missing from the application configuration, which leads to compilation issue if used with elixir 1.15.

Would it be possible to patch it and issue a new version on hex? Thanks!

